### PR TITLE
Implemented HyPlayer System

### DIFF
--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -3,7 +3,7 @@ import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.kotlin
 
 object Dependencies {
-    const val blazeApi = "com.github.KevinPriv:BlazeAPI:${Versions.blazeApi}"
+    const val blazeApi = "com.github.FalseHonesty:BlazeAPI:${Versions.blazeApi}"
 
     const val kryonet = "com.github.FalseHonesty:kryonet:${Versions.kryonet}"
     const val reflections = "com.github.FalseHonesty:reflections:${Versions.reflections}"

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -3,7 +3,7 @@ import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.kotlin
 
 object Dependencies {
-    const val blazeApi = "com.github.FalseHonesty:BlazeAPI:${Versions.blazeApi}"
+    const val blazeApi = "com.github.KevinPriv:BlazeAPI:${Versions.blazeApi}"
 
     const val kryonet = "com.github.FalseHonesty:kryonet:${Versions.kryonet}"
     const val reflections = "com.github.FalseHonesty:reflections:${Versions.reflections}"

--- a/src/main/java/cc/hyperium/imixins/entity/player/IMixinEntityPlayer.java
+++ b/src/main/java/cc/hyperium/imixins/entity/player/IMixinEntityPlayer.java
@@ -1,0 +1,7 @@
+package cc.hyperium.imixins.entity.player;
+
+import cc.hyperium.game.player.HyPlayer;
+
+public interface IMixinEntityPlayer {
+    HyPlayer getHyPlayer();
+}

--- a/src/main/java/cc/hyperium/mixins/entity/player/MixinEntityPlayer.java
+++ b/src/main/java/cc/hyperium/mixins/entity/player/MixinEntityPlayer.java
@@ -1,0 +1,26 @@
+package cc.hyperium.mixins.entity.player;
+
+import cc.hyperium.game.player.HyPlayer;
+import cc.hyperium.imixins.entity.player.IMixinEntityPlayer;
+import com.mojang.authlib.GameProfile;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EntityPlayer.class)
+public abstract class MixinEntityPlayer implements IMixinEntityPlayer {
+    private HyPlayer hyPlayer;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void init(World worldIn, GameProfile gameProfileIn, CallbackInfo ci) {
+        hyPlayer = new HyPlayer((EntityPlayer) (Object) this);
+    }
+
+    @Override
+    public HyPlayer getHyPlayer() {
+        return hyPlayer;
+    }
+}

--- a/src/main/kotlin/cc/hyperium/Hyperium.kt
+++ b/src/main/kotlin/cc/hyperium/Hyperium.kt
@@ -1,5 +1,6 @@
 package cc.hyperium
 
+import cc.hyperium.game.server.ServerRegistry
 import cc.hyperium.network.NetworkManager
 import cc.hyperium.processes.services.AbstractService
 import cc.hyperium.processes.services.ServiceRegistry
@@ -47,7 +48,6 @@ object Hyperium {
 
         // Time to start the client!
 
-
         // Asynchronously start the network connection.
         // We're using coroutines here because kotlin has them and they are cool!
         val networkJob = GlobalScope.launch {
@@ -68,6 +68,11 @@ object Hyperium {
         // This includes the command system, and other vital
         // client services.
         runningServices.bootstrap(reflections, kodein)
+
+        // Boot up the server registry.
+        // The server registry deals with what server is
+        // currently being played on and all the associated details.
+        ServerRegistry.bootstrap(reflections)
 
         // However, by the time we are starting the client, we want to be registered.
         // To confirm that this has happened, we will join the network job thread,

--- a/src/main/kotlin/cc/hyperium/game/player/HyPlayer.kt
+++ b/src/main/kotlin/cc/hyperium/game/player/HyPlayer.kt
@@ -1,18 +1,20 @@
 package cc.hyperium.game.player
 
-import cc.hyperium.game.server.ServerRegistry
+import cc.hyperium.imixins.entity.player.IMixinEntityPlayer
 import cc.hyperium.processes.Process
 import kotlinx.coroutines.Job
 import net.minecraft.entity.player.EntityPlayer
 
 /**
- * A class that holds all of the Hyperium
- * specific data for any EntityPlayer.
+ * A class that holds all of the Hyperium specific data for any EntityPlayer.
+ *
+ * This is attached to one single EntityPlayer,
+ * and will only exist while that EntityPlayer exists.
  */
 class HyPlayer(private val backingPlayer: EntityPlayer) : Process {
     override val childProcesses = mutableListOf<Process>()
     override lateinit var job: Job
 }
 
-val EntityPlayer.hyplayer: HyPlayer?
-    get() = ServerRegistry.currentServer?.playerMap?.get(this.uniqueID)
+val EntityPlayer.hyplayer: HyPlayer
+    get() = (this as IMixinEntityPlayer).hyPlayer

--- a/src/main/kotlin/cc/hyperium/game/player/HyPlayer.kt
+++ b/src/main/kotlin/cc/hyperium/game/player/HyPlayer.kt
@@ -1,0 +1,18 @@
+package cc.hyperium.game.player
+
+import cc.hyperium.game.server.ServerRegistry
+import cc.hyperium.processes.Process
+import kotlinx.coroutines.Job
+import net.minecraft.entity.player.EntityPlayer
+
+/**
+ * A class that holds all of the Hyperium
+ * specific data for any EntityPlayer.
+ */
+class HyPlayer(private val backingPlayer: EntityPlayer) : Process {
+    override val childProcesses = mutableListOf<Process>()
+    override lateinit var job: Job
+}
+
+val EntityPlayer.hyplayer: HyPlayer?
+    get() = ServerRegistry.currentServer?.playerMap?.get(this.uniqueID)

--- a/src/main/kotlin/cc/hyperium/game/server/MinecraftServer.kt
+++ b/src/main/kotlin/cc/hyperium/game/server/MinecraftServer.kt
@@ -1,12 +1,7 @@
 package cc.hyperium.game.server
 
-import cc.hyperium.game.player.HyPlayer
 import cc.hyperium.processes.Process
 import kotlinx.coroutines.Job
-import me.kbrewster.blazeapi.events.PlayerDespawnEvent
-import me.kbrewster.blazeapi.events.PlayerSpawnEvent
-import me.kbrewster.eventbus.Subscribe
-import java.util.*
 
 abstract class MinecraftServer(
     val addresses: Array<String>,
@@ -16,36 +11,13 @@ abstract class MinecraftServer(
     override val childProcesses = mutableListOf<Process>()
     override lateinit var job: Job
 
-    val playerMap = mutableMapOf<UUID, HyPlayer>()
-
-    @Subscribe
-    fun onPlayerJoin(e: PlayerSpawnEvent) {
-        if (playerMap.containsKey(e.player.uniqueID)) return
-
-        val hyplayer = HyPlayer(e.player)
-        hyplayer.initialize()
-
-        childProcesses.add(hyplayer)
-        playerMap[e.player.uniqueID] = hyplayer
-    }
-
-    @Subscribe
-    fun onPlayerLeave(e: PlayerDespawnEvent) {
-        val hyplayer = playerMap.remove(e.player.uniqueID) ?: return
-
-        hyplayer.kill()
-        childProcesses.remove(hyplayer)
-    }
-
     override fun initialize() {
         super.initialize()
-        playerMap.clear()
         onServerJoin()
     }
 
     override fun kill(): Boolean {
         onServerLeave()
-        playerMap.clear()
         return super.kill()
     }
 

--- a/src/main/kotlin/cc/hyperium/game/server/MinecraftServer.kt
+++ b/src/main/kotlin/cc/hyperium/game/server/MinecraftServer.kt
@@ -1,9 +1,55 @@
 package cc.hyperium.game.server
 
-open class MinecraftServer(val addresses: Array<String>, val port: Int = 25565) {
+import cc.hyperium.game.player.HyPlayer
+import cc.hyperium.processes.Process
+import kotlinx.coroutines.Job
+import me.kbrewster.blazeapi.events.PlayerDespawnEvent
+import me.kbrewster.blazeapi.events.PlayerSpawnEvent
+import me.kbrewster.eventbus.Subscribe
+import java.util.*
+
+abstract class MinecraftServer(
+    val addresses: Array<String>,
+    val port: Int = 25565
+) : Process {
+
+    override val childProcesses = mutableListOf<Process>()
+    override lateinit var job: Job
+
+    val playerMap = mutableMapOf<UUID, HyPlayer>()
+
+    @Subscribe
+    fun onPlayerJoin(e: PlayerSpawnEvent) {
+        if (playerMap.containsKey(e.player.uniqueID)) return
+
+        val hyplayer = HyPlayer(e.player)
+        hyplayer.initialize()
+
+        childProcesses.add(hyplayer)
+        playerMap[e.player.uniqueID] = hyplayer
+    }
+
+    @Subscribe
+    fun onPlayerLeave(e: PlayerDespawnEvent) {
+        val hyplayer = playerMap.remove(e.player.uniqueID) ?: return
+
+        hyplayer.kill()
+        childProcesses.remove(hyplayer)
+    }
+
+    override fun initialize() {
+        super.initialize()
+        playerMap.clear()
+        onServerJoin()
+    }
+
+    override fun kill(): Boolean {
+        onServerLeave()
+        playerMap.clear()
+        return super.kill()
+    }
 
     fun onServerJoin() {}
 
     fun onServerLeave() {}
-
 }

--- a/src/main/kotlin/cc/hyperium/game/server/ServerRegistry.kt
+++ b/src/main/kotlin/cc/hyperium/game/server/ServerRegistry.kt
@@ -2,23 +2,40 @@ package cc.hyperium.game.server
 
 import cc.hyperium.processes.services.utilities.RegisterEvents
 import cc.hyperium.utils.Registry
+import cc.hyperium.utils.instance
+import me.kbrewster.blazeapi.EVENT_BUS
 import me.kbrewster.blazeapi.events.ServerDisconnectEvent
 import me.kbrewster.blazeapi.events.ServerJoinEvent
 import me.kbrewster.eventbus.Subscribe
+import org.reflections.Reflections
 
 @RegisterEvents
 object ServerRegistry : Registry<MinecraftServer>() {
-    private var currentServer: MinecraftServer? = null
+    var currentServer: MinecraftServer? = null
+
+    fun bootstrap(ref: Reflections) {
+        ref.getSubTypesOf(MinecraftServer::class.java).forEach {
+            add(it.instance())
+        }
+    }
 
     @Subscribe
     fun joinServer(e: ServerJoinEvent) {
         this.currentServer = this.find { it.addresses.contains(e.ip) && it.port == e.port }
-        this.currentServer?.onServerJoin()
+
+        this.currentServer?.let {
+            EVENT_BUS.register(it)
+            it.initialize()
+        }
     }
 
     @Subscribe
     fun leaveServer(e: ServerDisconnectEvent) {
-        this.currentServer?.onServerLeave()
+        this.currentServer?.let {
+            EVENT_BUS.unregister(it)
+            it.kill()
+        }
+
         this.currentServer = null
     }
 }

--- a/src/main/kotlin/cc/hyperium/game/server/ServerRegistry.kt
+++ b/src/main/kotlin/cc/hyperium/game/server/ServerRegistry.kt
@@ -32,8 +32,8 @@ object ServerRegistry : Registry<MinecraftServer>() {
     @Subscribe
     fun leaveServer(e: ServerDisconnectEvent) {
         this.currentServer?.let {
-            EVENT_BUS.unregister(it)
             it.kill()
+            EVENT_BUS.unregister(it)
         }
 
         this.currentServer = null

--- a/src/main/kotlin/cc/hyperium/game/server/servers/Hypixel.kt
+++ b/src/main/kotlin/cc/hyperium/game/server/servers/Hypixel.kt
@@ -1,9 +1,8 @@
-package cc.hyperium.game.server.hypixel
+package cc.hyperium.game.server.servers
 
 import cc.hyperium.game.server.MinecraftServer
 
 class Hypixel : MinecraftServer(
-    arrayOf("mc.hypixel.net"), 25565
+    arrayOf("mc.hypixel.net")
 ) {
-
 }

--- a/src/main/kotlin/cc/hyperium/game/server/servers/Hypixel.kt
+++ b/src/main/kotlin/cc/hyperium/game/server/servers/Hypixel.kt
@@ -5,4 +5,5 @@ import cc.hyperium.game.server.MinecraftServer
 class Hypixel : MinecraftServer(
     arrayOf("mc.hypixel.net")
 ) {
+
 }

--- a/src/main/kotlin/cc/hyperium/game/server/servers/SinglePlayer.kt
+++ b/src/main/kotlin/cc/hyperium/game/server/servers/SinglePlayer.kt
@@ -5,4 +5,5 @@ import cc.hyperium.game.server.MinecraftServer
 class SinglePlayer : MinecraftServer(
     arrayOf("localhost")
 ) {
+
 }

--- a/src/main/kotlin/cc/hyperium/game/server/servers/SinglePlayer.kt
+++ b/src/main/kotlin/cc/hyperium/game/server/servers/SinglePlayer.kt
@@ -1,0 +1,8 @@
+package cc.hyperium.game.server.servers
+
+import cc.hyperium.game.server.MinecraftServer
+
+class SinglePlayer : MinecraftServer(
+    arrayOf("localhost")
+) {
+}

--- a/src/main/kotlin/cc/hyperium/processes/services/commands/CmdTest.kt
+++ b/src/main/kotlin/cc/hyperium/processes/services/commands/CmdTest.kt
@@ -1,12 +1,14 @@
 package cc.hyperium.processes.services.commands
 
 import cc.hyperium.Hyperium
+import cc.hyperium.game.player.hyplayer
 import cc.hyperium.network.NetworkManager
 import cc.hyperium.network.packets.CrossClientData
 import cc.hyperium.network.packets.Packets
 import cc.hyperium.processes.services.commands.api.Command
 import cc.hyperium.processes.services.commands.api.Greedy
 import cc.hyperium.processes.services.commands.api.Quotable
+import me.kbrewster.blazeapi.client.thePlayer
 import org.kodein.di.generic.instance
 import java.util.*
 
@@ -29,6 +31,13 @@ object CmdTest {
         }
 
         println(if (res) "Sent packet!" else "Failed to send packet :(")
+    }
+
+    @Command("player")
+    fun getPlayer(name: Optional<String>) {
+        if (!name.isPresent) {
+            println(thePlayer.hyplayer)
+        }
     }
 
     @Command("gay")

--- a/src/main/kotlin/cc/hyperium/processes/services/keybind/KeyboardKey.kt
+++ b/src/main/kotlin/cc/hyperium/processes/services/keybind/KeyboardKey.kt
@@ -29,10 +29,10 @@ class LWJGLKey(keyName: String, keyCode: Int) :
 
     }
 
-    override fun equals(o: Any?): Boolean {
-        if (this === o) return true
-        if (o == null || javaClass != o.javaClass) return false
-        return this.keyCode == (o as LWJGLKey).keyCode
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || javaClass != other.javaClass) return false
+        return this.keyCode == (other as LWJGLKey).keyCode
     }
 
     override fun hashCode(): Int {

--- a/src/main/kotlin/cc/hyperium/utils/Registry.kt
+++ b/src/main/kotlin/cc/hyperium/utils/Registry.kt
@@ -5,16 +5,8 @@ import org.kodein.di.TypeToken
 
 open class Registry<T : Any> : ArrayList<T>() {
 
-    fun register(element: T): Boolean {
-        return this.add(element)
-    }
-
-    fun register(index: Int, element: T) {
-        this.add(index, element)
-    }
-
-    fun unregister(obj: T) {
-        this.remove(obj)
+    open operator fun plusAssign(item: T) {
+        add(item)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/cc/hyperium/utils/rendering.kt
+++ b/src/main/kotlin/cc/hyperium/utils/rendering.kt
@@ -9,12 +9,10 @@ import org.lwjgl.input.Mouse
 
 @RegisterEvents
 class Rendering {
-
     @Subscribe
     fun onTick(event: ClientTickEvent) {
         scaledResolution = ScaledResolution(mc)
     }
-
 }
 
 var scaledResolution = ScaledResolution(mc)

--- a/src/main/resources/mixins.hyperium.json
+++ b/src/main/resources/mixins.hyperium.json
@@ -7,6 +7,7 @@
   "mixins": [
     "MixinMinecraft",
     "client.resources.MixinLocale",
-    "renderer.MixinRenderManager"
+    "renderer.MixinRenderManager",
+    "entity.player.MixinEntityPlayer"
   ]
 }


### PR DESCRIPTION
# Description

For many different client systems, there will need to be custom data attached to players. The way this was done in the Hyperium Java was through the use of maps to those specific pieces of data in every system where it was required. This is a waste of space and efficiency, and this pull request aims to fix that by having all player-specific data stored in the `HyPlayer` equivalent to an `EntityPlayer`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] Any dependent changes have been merged and published in downstream modules
