### PR TITLE
MC Fixes (from Kevin)

### DIFF
--- a/src/main/java/cc/hyperium/mixins/MixinMinecraft.java
+++ b/src/main/java/cc/hyperium/mixins/MixinMinecraft.java
@@ -3,6 +3,7 @@ package cc.hyperium.mixins;
 import cc.hyperium.Hyperium;
 import me.kbrewster.blazeapi.BlazeAPI;
 import net.minecraft.client.Minecraft;
+import org.lwjgl.opengl.Display;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -10,8 +11,20 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Minecraft.class)
 public class MixinMinecraft {
+
     @Inject(method = "startGame", at = @At("HEAD"))
     private void startGame(CallbackInfo ci) {
         BlazeAPI.getEventBus().register(Hyperium.INSTANCE);
+    }
+
+    /**
+     * Fixes bug MC-68754 and MC-111254
+     *
+     * @param ci
+     */
+    @Inject(method = "toggleFullscreen", at = @At(value = "JUMP", target = "Lnet/minecraft/client/Minecraft;toggleFullscreen()V", shift = At.Shift.AFTER))
+    private void toggleFullScreen(CallbackInfo ci) {
+        Display.setResizable(false);
+        Display.setResizable(true);
     }
 }

--- a/src/main/java/cc/hyperium/mixins/entity/MixinEntity.java
+++ b/src/main/java/cc/hyperium/mixins/entity/MixinEntity.java
@@ -1,0 +1,14 @@
+package cc.hyperium.mixins.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(Entity.class)
+public class MixinEntity {
+    @Shadow
+    public Vec3 getLook(float particalTicks) {
+        return null;
+    }
+}

--- a/src/main/java/cc/hyperium/mixins/entity/MixinEntityLivingBase.java
+++ b/src/main/java/cc/hyperium/mixins/entity/MixinEntityLivingBase.java
@@ -1,0 +1,29 @@
+package cc.hyperium.mixins.entity;
+
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(EntityLivingBase.class)
+public abstract class MixinEntityLivingBase extends MixinEntity {
+
+    /**
+     * Prevents issue where Mouse Updates less frequently than it should in 1.8.9
+     * MC-67665
+     *
+     * @param partialTicks
+     * @param ci
+     */
+    @Inject(method = "getLook", at = @At("HEAD"), cancellable = true)
+    private void getLook(float partialTicks, CallbackInfoReturnable<Vec3> ci) {
+        EntityLivingBase base = (EntityLivingBase) (Object) this;
+        if (base instanceof EntityPlayerSP) {
+            ci.setReturnValue(super.getLook(partialTicks));
+        }
+    }
+
+}

--- a/src/main/java/cc/hyperium/mixins/entity/MixinRenderPlayer.java
+++ b/src/main/java/cc/hyperium/mixins/entity/MixinRenderPlayer.java
@@ -1,0 +1,38 @@
+package cc.hyperium.mixins.entity;
+
+import net.minecraft.client.entity.AbstractClientPlayer;
+import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.model.ModelPlayer;
+import net.minecraft.client.renderer.entity.RenderManager;
+import net.minecraft.client.renderer.entity.RenderPlayer;
+import net.minecraft.client.renderer.entity.RendererLivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RenderPlayer.class)
+public abstract class MixinRenderPlayer extends RendererLivingEntity<AbstractClientPlayer> {
+
+    public MixinRenderPlayer(RenderManager renderManagerIn, ModelBase modelBaseIn, float shadowSizeIn) {
+        super(renderManagerIn, modelBaseIn, shadowSizeIn);
+    }
+
+    @Shadow
+    public abstract ModelPlayer getMainModel();
+
+    /**
+     * Fixes bug MC-1349
+     *
+     * @param clientPlayer
+     * @param ci
+     */
+    @Inject(method = "renderRightArm", at = @At(value = "FIELD", ordinal = 3))
+    private void onUpdateTimer(AbstractClientPlayer clientPlayer, CallbackInfo ci) {
+        ModelPlayer modelplayer = this.getMainModel();
+        modelplayer.isRiding = modelplayer.isSneak = false;
+    }
+
+
+}

--- a/src/main/java/cc/hyperium/mixins/gui/MixinGuiGameOver.java
+++ b/src/main/java/cc/hyperium/mixins/gui/MixinGuiGameOver.java
@@ -1,0 +1,25 @@
+package cc.hyperium.mixins.gui;
+
+import net.minecraft.client.gui.GuiGameOver;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GuiGameOver.class)
+public class MixinGuiGameOver {
+
+    @Shadow
+    private int enableButtonsTimer;
+
+    /**
+     * Fixes bug MC-2835
+     *
+     * @param ci
+     */
+    @Inject(method = "initGui", at = @At("HEAD"))
+    private void initGui(CallbackInfo ci) {
+        this.enableButtonsTimer = 0;
+    }
+}

--- a/src/main/java/cc/hyperium/mixins/gui/MixinGuiScreen.java
+++ b/src/main/java/cc/hyperium/mixins/gui/MixinGuiScreen.java
@@ -1,0 +1,16 @@
+package cc.hyperium.mixins.gui;
+
+import net.minecraft.client.gui.GuiScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GuiScreen.class)
+public abstract class MixinGuiScreen {
+
+    @Inject(method = "handleKeyboardInput", at = @At("HEAD"))
+    private void handleKeyboardInput(CallbackInfo ci) {
+        // TODO: Fix MC-2781
+    }
+}

--- a/src/main/java/cc/hyperium/mixins/gui/MixinInventoryEffectRenderer.java
+++ b/src/main/java/cc/hyperium/mixins/gui/MixinInventoryEffectRenderer.java
@@ -1,0 +1,37 @@
+package cc.hyperium.mixins.gui;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.renderer.InventoryEffectRenderer;
+import net.minecraft.inventory.Container;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(InventoryEffectRenderer.class)
+public abstract class MixinInventoryEffectRenderer extends GuiContainer {
+
+    @Shadow
+    private boolean hasActivePotionEffects;
+
+    public MixinInventoryEffectRenderer(Container inventorySlotsIn) {
+        super(inventorySlotsIn);
+    }
+
+    /**
+     * Removes the inventory going to the left once potion effects have worn out
+     *
+     * @author Kevin
+     */
+    @Inject(method = "updateActivePotionEffects", at = @At("HEAD"))
+    private void updateActivePotionEffects(CallbackInfo ci) {
+        // TODO: Once config system is complete we can cancel if they want status effects to move the inventory
+        if (false) {
+            this.hasActivePotionEffects = !Minecraft.getMinecraft().thePlayer.getActivePotionEffects().isEmpty();
+            this.guiLeft = (this.width - this.xSize) / 2;
+        }
+    }
+
+}

--- a/src/main/resources/mixins.hyperium.json
+++ b/src/main/resources/mixins.hyperium.json
@@ -7,6 +7,12 @@
   "mixins": [
     "MixinMinecraft",
     "client.resources.MixinLocale",
+    "entity.MixinEntity",
+    "entity.MixinEntityLivingBase",
+    "entity.MixinRenderPlayer",
+    "gui.MixinGuiGameOver",
+    "gui.MixinGuiScreen",
+    "gui.MixinInventoryEffectRenderer",
     "renderer.MixinRenderManager"
   ]
 }


### PR DESCRIPTION
# Description
The push fixes essential Minecraft 1.8.9 issues which are fixed in there future updates.

THIS IS ALL FROM #10, but I opened this because that PR had unnecessary files.

This includes:
- MC-67665
- MC-1349
- MC-2835
- MC-68754 and MC-111254
- Potion effects moving to the left once expiring (nobody actually likes this, still needs a toggle though.)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update